### PR TITLE
Use vectors in Camera interface

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -48,11 +48,11 @@ impl<T: Float + FloatMath + Copy> Camera<T> {
     /// Constructs a new camera.
     ///
     /// Places the camera at [x, y, z], looking towards pozitive z.
-    pub fn new(x: T, y: T, z: T) -> Camera<T> {
+    pub fn new(position: Vector3<T>) -> Camera<T> {
         let _0 = Float::zero();
         let _1 = Float::one();
         Camera {
-            position: [x, y, z],
+            position: position,
             right:   [_1, _0, _0],
             up:      [_0, _1, _0],
             forward: [_0, _0, _1]
@@ -77,8 +77,8 @@ impl<T: Float + FloatMath + Copy> Camera<T> {
     }
 
     /// Orients the camera to look at a point.
-    pub fn look_at(&mut self, x: T, y: T, z: T) {
-        self.forward = vec3_normalized_sub(self.position, [x, y, z]);
+    pub fn look_at(&mut self, point: Vector3<T>) {
+        self.forward = vec3_normalized_sub(self.position, point);
         self.update_right();
     }
 

--- a/src/first_person.rs
+++ b/src/first_person.rs
@@ -121,11 +121,11 @@ impl<T: Float + FromPrimitive + Copy + FloatMath> FirstPerson<T> {
         let dh = dt * self.velocity * self.settings.speed_horizontal;
         let [dx, dy, dz] = self.direction;
         let (s, c) = (self.yaw.sin(), self.yaw.cos());
-        let mut camera = Camera::new(
+        let mut camera = Camera::new([
             self.position[0] + (s * dx - c * dz) * dh,
             self.position[1] + dy * dt * self.settings.speed_vertical,
             self.position[2] + (s * dz + c * dx) * dh
-        );
+        ]);
         camera.set_yaw_pitch(self.yaw, self.pitch);
         camera
     }


### PR DESCRIPTION
Using vectors wraps up the relation between the coordinates and makes it also easier to pass actual vectors as arguments. This is especially tedious when the vector to pass as argument is a complex expression. The obvious drawback of this change is, that to use this with individual components one now has to assemble them into a vector by adding [] first.
